### PR TITLE
PIPE-60 Adding slack channel to the dashboard link

### DIFF
--- a/src/template/modules.js
+++ b/src/template/modules.js
@@ -48,7 +48,7 @@ function buildLink(key, site) {
     case 'sonarqube':
       return site.sonarqube_base + '/';
     case 'chat':
-      return site.chat_base + '/';
+      return site.chat_base + '/messages/' + site.chat_room;
     case 'devenv':
       return 'http://dev.' + site.app_name + '.' + site.tools_domain;
     default:

--- a/src/template/site.js
+++ b/src/template/site.js
@@ -3,6 +3,7 @@ const site = {
   project_name: '__PROJECT_NAME__',
   project_key: '__PROJECT_KEY__',
   app_name: '__APP_NAME__',
+  chat_room: '__CHAT_ROOM__',
   logo_file: 'logo.png',
   tools_domain: 'liatr.io',
   footer: 'Fail fast.',


### PR DESCRIPTION
Will now be parameterized at __CHAT_ROOM__ so we can link directly to it...